### PR TITLE
Remove logging on Micro-ROS rcutils

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(rcutils)
 
 option(RCUTILS_NO_THREAD_SUPPORT "Disable thread support." OFF)
 option(RCUTILS_NO_FILESYSTEM "Disable filesystem usage." OFF)
+option(RCUTILS_NO_LOGGING "Disable logging usage." OFF)
 option(RCUTILS_AVOID_DYNAMIC_ALLOCATION "Disable dynamic allocations." OFF)
 
 # Default to C11

--- a/include/rcutils/configuration_flags.h.in
+++ b/include/rcutils/configuration_flags.h.in
@@ -8,6 +8,7 @@ extern "C"
 #endif
 
 #cmakedefine RCUTILS_NO_FILESYSTEM
+#cmakedefine RCUTILS_NO_LOGGING
 #cmakedefine RCUTILS_AVOID_DYNAMIC_ALLOCATION
 #cmakedefine RCUTILS_NO_THREAD_SUPPORT
 

--- a/include/rcutils/error_handling.h
+++ b/include/rcutils/error_handling.h
@@ -57,19 +57,33 @@ extern "C"
 #define RCUTILS_ERROR_FORMATTING_CHARACTERS 6  // ', at ' + ':'
 
 // max formatted string length
+#ifndef RCUTILS_NO_LOGGING
 #define RCUTILS_ERROR_MESSAGE_MAX_LENGTH 1024
+#else
+#define RCUTILS_ERROR_MESSAGE_MAX_LENGTH 1
+#endif //RCUTILS_NO_LOGGING
 
 // adjustable max length for user defined error message
 // remember "chained" errors will include previously specified file paths
 // e.g. "some error, at /path/to/a.c:42, at /path/to/b.c:42"
+#ifndef RCUTILS_NO_LOGGING
 #define RCUTILS_ERROR_STATE_MESSAGE_MAX_LENGTH 768
+#else
+#define RCUTILS_ERROR_STATE_MESSAGE_MAX_LENGTH 1
+#endif //RCUTILS_NO_LOGGING
 // with RCUTILS_ERROR_STATE_MESSAGE_MAX_LENGTH = 768, RCUTILS_ERROR_STATE_FILE_MAX_LENGTH == 229
+
+#ifndef RCUTILS_NO_LOGGING
 #define RCUTILS_ERROR_STATE_FILE_MAX_LENGTH ( \
     RCUTILS_ERROR_MESSAGE_MAX_LENGTH - \
     RCUTILS_ERROR_STATE_MESSAGE_MAX_LENGTH - \
     RCUTILS_ERROR_STATE_LINE_NUMBER_STR_MAX_LENGTH - \
     RCUTILS_ERROR_FORMATTING_CHARACTERS - \
     1)
+#else
+#define RCUTILS_ERROR_STATE_FILE_MAX_LENGTH 1
+#endif //RCUTILS_NO_LOGGING
+
 
 /// Struct wrapping a fixed-size c string used for returning the formatted error string.
 typedef struct rcutils_error_string_t
@@ -90,7 +104,7 @@ typedef struct rcutils_error_state_t
 } rcutils_error_state_t;
 
 // make sure our math is right...
-#if __STDC_VERSION__ >= 201112L
+#if __STDC_VERSION__ >= 201112L && !defined(RCUTILS_NO_LOGGING)
 static_assert(
   sizeof(rcutils_error_string_t) == (
     RCUTILS_ERROR_STATE_MESSAGE_MAX_LENGTH +

--- a/include/rcutils/logging.h
+++ b/include/rcutils/logging.h
@@ -24,6 +24,7 @@
 #include "rcutils/time.h"
 #include "rcutils/types/rcutils_ret.h"
 #include "rcutils/visibility_control.h"
+#include "rcutils/configuration_flags.h"
 
 #ifdef __cplusplus
 extern "C"
@@ -539,22 +540,22 @@ void rcutils_logging_console_output_handler(
  * All logging macros ensure that this has been called once.
  */
 
+#ifdef RCUTILS_NO_LOGGING
 #define RCUTILS_LOGGING_AUTOINIT
-
-/**
-* #define RCUTILS_LOGGING_AUTOINIT \
-*   if (RCUTILS_UNLIKELY(!g_rcutils_logging_initialized)) { \
-*     rcutils_ret_t ret = rcutils_logging_initialize(); \
-*     if (ret != RCUTILS_RET_OK) { \
-*       RCUTILS_SAFE_FWRITE_TO_STDERR( \
-*         "[rcutils|" __FILE__ ":" RCUTILS_STRINGIFY(__LINE__) \
-*         "] error initializing logging: "); \
-*       RCUTILS_SAFE_FWRITE_TO_STDERR(rcutils_get_error_string().str); \
-*       RCUTILS_SAFE_FWRITE_TO_STDERR("\n"); \
-*       rcutils_reset_error(); \
-*     } \
-*   }
-*/
+#else
+#define RCUTILS_LOGGING_AUTOINIT \
+  if (RCUTILS_UNLIKELY(!g_rcutils_logging_initialized)) { \
+    rcutils_ret_t ret = rcutils_logging_initialize(); \
+    if (ret != RCUTILS_RET_OK) { \
+      RCUTILS_SAFE_FWRITE_TO_STDERR( \
+        "[rcutils|" __FILE__ ":" RCUTILS_STRINGIFY(__LINE__) \
+        "] error initializing logging: "); \
+      RCUTILS_SAFE_FWRITE_TO_STDERR(rcutils_get_error_string().str); \
+      RCUTILS_SAFE_FWRITE_TO_STDERR("\n"); \
+      rcutils_reset_error(); \
+    } \
+  }
+#endif // RCUTILS_NO_LOGGING
 
 #ifdef __cplusplus
 }

--- a/include/rcutils/logging.h
+++ b/include/rcutils/logging.h
@@ -538,18 +538,21 @@ void rcutils_logging_console_output_handler(
  * Usually it is unnecessary to call the macro directly.
  * All logging macros ensure that this has been called once.
  */
-#define RCUTILS_LOGGING_AUTOINIT \
-  if (RCUTILS_UNLIKELY(!g_rcutils_logging_initialized)) { \
-    rcutils_ret_t ret = rcutils_logging_initialize(); \
-    if (ret != RCUTILS_RET_OK) { \
-      RCUTILS_SAFE_FWRITE_TO_STDERR( \
-        "[rcutils|" __FILE__ ":" RCUTILS_STRINGIFY(__LINE__) \
-        "] error initializing logging: "); \
-      RCUTILS_SAFE_FWRITE_TO_STDERR(rcutils_get_error_string().str); \
-      RCUTILS_SAFE_FWRITE_TO_STDERR("\n"); \
-      rcutils_reset_error(); \
-    } \
-  }
+
+#define RCUTILS_LOGGING_AUTOINIT
+
+// #define RCUTILS_LOGGING_AUTOINIT \
+//   if (RCUTILS_UNLIKELY(!g_rcutils_logging_initialized)) { \
+//     rcutils_ret_t ret = rcutils_logging_initialize(); \
+//     if (ret != RCUTILS_RET_OK) { \
+//       RCUTILS_SAFE_FWRITE_TO_STDERR( \
+//         "[rcutils|" __FILE__ ":" RCUTILS_STRINGIFY(__LINE__) \
+//         "] error initializing logging: "); \
+//       RCUTILS_SAFE_FWRITE_TO_STDERR(rcutils_get_error_string().str); \
+//       RCUTILS_SAFE_FWRITE_TO_STDERR("\n"); \
+//       rcutils_reset_error(); \
+//     } \
+//   }
 
 #ifdef __cplusplus
 }

--- a/include/rcutils/logging.h
+++ b/include/rcutils/logging.h
@@ -541,18 +541,20 @@ void rcutils_logging_console_output_handler(
 
 #define RCUTILS_LOGGING_AUTOINIT
 
-// #define RCUTILS_LOGGING_AUTOINIT \
-//   if (RCUTILS_UNLIKELY(!g_rcutils_logging_initialized)) { \
-//     rcutils_ret_t ret = rcutils_logging_initialize(); \
-//     if (ret != RCUTILS_RET_OK) { \
-//       RCUTILS_SAFE_FWRITE_TO_STDERR( \
-//         "[rcutils|" __FILE__ ":" RCUTILS_STRINGIFY(__LINE__) \
-//         "] error initializing logging: "); \
-//       RCUTILS_SAFE_FWRITE_TO_STDERR(rcutils_get_error_string().str); \
-//       RCUTILS_SAFE_FWRITE_TO_STDERR("\n"); \
-//       rcutils_reset_error(); \
-//     } \
-//   }
+/**
+* #define RCUTILS_LOGGING_AUTOINIT \
+*   if (RCUTILS_UNLIKELY(!g_rcutils_logging_initialized)) { \
+*     rcutils_ret_t ret = rcutils_logging_initialize(); \
+*     if (ret != RCUTILS_RET_OK) { \
+*       RCUTILS_SAFE_FWRITE_TO_STDERR( \
+*         "[rcutils|" __FILE__ ":" RCUTILS_STRINGIFY(__LINE__) \
+*         "] error initializing logging: "); \
+*       RCUTILS_SAFE_FWRITE_TO_STDERR(rcutils_get_error_string().str); \
+*       RCUTILS_SAFE_FWRITE_TO_STDERR("\n"); \
+*       rcutils_reset_error(); \
+*     } \
+*   }
+*/
 
 #ifdef __cplusplus
 }

--- a/resource/logging_macros.h.em
+++ b/resource/logging_macros.h.em
@@ -69,6 +69,7 @@ extern "C"
  * \param name The name of the logger
  * \param ... The format string, followed by the variable arguments for the format string
  */
+#ifdef RCUTILS_NO_LOGGING
 #define RCUTILS_LOG_COND_NAMED(severity, condition_before, condition_after, name, ...) \
   do { \
     RCUTILS_LOGGING_AUTOINIT \
@@ -79,6 +80,9 @@ extern "C"
       condition_after \
     } \
   } while (0)
+#else
+#define RCUTILS_LOG_COND_NAMED(severity, condition_before, condition_after, name, ...)
+#endif //RCUTILS_NO_LOGGING
 
 ///@@{
 /**

--- a/resource/logging_macros.h.em
+++ b/resource/logging_macros.h.em
@@ -20,6 +20,7 @@
 #define RCUTILS__LOGGING_MACROS_H_
 
 #include "rcutils/logging.h"
+#include "rcutils/configuration_flags.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -43,6 +44,11 @@ extern "C"
  * in your build options to compile out anything below that severity.
  * Use RCUTILS_LOG_MIN_SEVERITY_NONE to compile out all macros.
  */
+
+#ifdef RCUTILS_NO_LOGGING
+#define RCUTILS_LOG_MIN_SEVERITY RCUTILS_LOG_MIN_SEVERITY_NONE
+#endif //RCUTILS_NO_LOGGING
+
 #ifndef RCUTILS_LOG_MIN_SEVERITY
 #define RCUTILS_LOG_MIN_SEVERITY RCUTILS_LOG_MIN_SEVERITY_DEBUG
 #endif

--- a/src/error_handling.c
+++ b/src/error_handling.c
@@ -242,18 +242,22 @@ rcutils_get_error_string(void)
   return gtls_rcutils_error_string;
 }
 
+// void
+// rcutils_reset_error(void)
+// {
+//   gtls_rcutils_error_state = (const rcutils_error_state_t) {
+//     .message = {0}, .file = {0}, .line_number = 0
+//   };  // NOLINT(readability/braces)
+//   gtls_rcutils_error_string_is_formatted = false;
+//   gtls_rcutils_error_string = (const rcutils_error_string_t) {
+//     .str = "\0"
+//   };
+//   gtls_rcutils_error_is_set = false;
+// }
+
 void
 rcutils_reset_error(void)
-{
-  gtls_rcutils_error_state = (const rcutils_error_state_t) {
-    .message = {0}, .file = {0}, .line_number = 0
-  };  // NOLINT(readability/braces)
-  gtls_rcutils_error_string_is_formatted = false;
-  gtls_rcutils_error_string = (const rcutils_error_string_t) {
-    .str = "\0"
-  };
-  gtls_rcutils_error_is_set = false;
-}
+{}
 
 #ifdef __cplusplus
 }

--- a/src/error_handling.c
+++ b/src/error_handling.c
@@ -29,6 +29,7 @@ extern "C"
 #include <rcutils/allocator.h>
 #include <rcutils/macros.h>
 #include <rcutils/strdup.h>
+#include "rcutils/configuration_flags.h"
 
 // RCUTILS_REPORT_ERROR_HANDLING_ERRORS and RCUTILS_WARN_ON_TRUNCATION are set in the header below
 #include "./error_handling_helpers.h"
@@ -242,22 +243,20 @@ rcutils_get_error_string(void)
   return gtls_rcutils_error_string;
 }
 
-// void
-// rcutils_reset_error(void)
-// {
-//   gtls_rcutils_error_state = (const rcutils_error_state_t) {
-//     .message = {0}, .file = {0}, .line_number = 0
-//   };  // NOLINT(readability/braces)
-//   gtls_rcutils_error_string_is_formatted = false;
-//   gtls_rcutils_error_string = (const rcutils_error_string_t) {
-//     .str = "\0"
-//   };
-//   gtls_rcutils_error_is_set = false;
-// }
-
 void
 rcutils_reset_error(void)
-{}
+{
+#ifndef RCUTILS_NO_LOGGING
+  gtls_rcutils_error_state = (const rcutils_error_state_t) {
+    .message = {0}, .file = {0}, .line_number = 0
+  };  // NOLINT(readability/braces)
+  gtls_rcutils_error_string_is_formatted = false;
+  gtls_rcutils_error_string = (const rcutils_error_string_t) {
+    .str = "\0"
+  };
+  gtls_rcutils_error_is_set = false;
+#endif // RCUTILS_NO_LOGGING
+}
 
 #ifdef __cplusplus
 }

--- a/src/error_handling.c
+++ b/src/error_handling.c
@@ -44,6 +44,7 @@ RCUTILS_THREAD_LOCAL bool gtls_rcutils_error_is_set = false;
 rcutils_ret_t
 rcutils_initialize_error_handling_thread_local_storage(rcutils_allocator_t allocator)
 {
+#ifndef RCUTILS_NO_LOGGING
   if (gtls_rcutils_thread_local_initialized) {
     return RCUTILS_RET_OK;
   }
@@ -72,6 +73,8 @@ rcutils_initialize_error_handling_thread_local_storage(rcutils_allocator_t alloc
   rcutils_reset_error();
 
   // at this point the thread-local allocator, error state, and error string are all initialized
+
+#endif // RCUTILS_NO_LOGGING
   return RCUTILS_RET_OK;
 }
 
@@ -91,6 +94,8 @@ __format_overwriting_error_state_message(
   size_t buffer_size,
   const rcutils_error_state_t * new_error_state)
 {
+
+#ifndef RCUTILS_NO_LOGGING
   assert(NULL != buffer);
   assert(0 != buffer_size);
   assert(INT64_MAX > buffer_size);
@@ -161,7 +166,10 @@ __format_overwriting_error_state_message(
   }
 #else
   (void)bytes_left;  // avoid scope could be reduced warning if in this case
-#endif
+#endif // RCUTILS_REPORT_ERROR_HANDLING_ERRORS
+
+#endif // RCUTILS_NO_LOGGING
+
 }
 
 void
@@ -170,6 +178,9 @@ rcutils_set_error_state(
   const char * file,
   size_t line_number)
 {
+
+#ifndef RCUTILS_NO_LOGGING
+
   rcutils_error_state_t error_state;
 
   if (NULL == error_string) {
@@ -216,6 +227,9 @@ rcutils_set_error_state(
     .str = "\0"
   };
   gtls_rcutils_error_is_set = true;
+  
+#endif // RCUTILS_NO_LOGGING
+
 }
 
 bool
@@ -233,6 +247,7 @@ rcutils_get_error_state(void)
 rcutils_error_string_t
 rcutils_get_error_string(void)
 {
+#ifndef RCUTILS_NO_LOGGING
   if (!gtls_rcutils_error_is_set) {
     return (rcutils_error_string_t) {"error not set"};  // NOLINT(readability/braces)
   }
@@ -241,6 +256,9 @@ rcutils_get_error_string(void)
     gtls_rcutils_error_string_is_formatted = true;
   }
   return gtls_rcutils_error_string;
+#else
+  return (rcutils_error_string_t) {"rcutils error handling disabled"};
+#endif // RCUTILS_NO_LOGGING
 }
 
 void

--- a/src/error_handling_helpers.h
+++ b/src/error_handling_helpers.h
@@ -39,6 +39,7 @@
 #include <string.h>
 
 #include <rcutils/error_handling.h>
+#include "rcutils/configuration_flags.h"
 
 #ifdef __cplusplus
 extern "C"
@@ -140,6 +141,8 @@ __rcutils_format_error_string(
   rcutils_error_string_t * error_string,
   const rcutils_error_state_t * error_state)
 {
+#ifndef RCUTILS_NO_LOGGING
+  
   assert(error_string != NULL);
   assert(error_state != NULL);
   static const char format_1[] = ", at ";
@@ -173,6 +176,8 @@ __rcutils_format_error_string(
   written = __rcutils_copy_string(offset, bytes_left, line_number_buffer);
   offset += written;
   offset[0] = '\0';
+
+#endif // RCUTILS_NO_LOGGING
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
This PR removes some functions related to dynamic memory allocation and error management not working on Micro-ROS

May require discussion.

Related to:

- [x] https://github.com/micro-ROS/micro-ros-build/pull/104
- [x] https://github.com/micro-ROS/freertos_apps/pull/2
- [x] https://github.com/micro-ROS/rmw-microxrcedds/pull/59
- [x] https://github.com/micro-ROS/rcl/pull/5