### PR TITLE
Compatibility with NuttX-11

### DIFF
--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -59,7 +59,7 @@ extern "C"
 #endif  // _WIN32
 
 #ifdef RCUTILS_NO_FILESYSTEM
-#ifndef __INCLUDE_DIRENT_H
+#ifndef __NuttX__
   typedef int DIR;
 #endif
 #endif  // _RCUTILS_NO_FILESYSTEM

--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -59,7 +59,9 @@ extern "C"
 #endif  // _WIN32
 
 #ifdef RCUTILS_NO_FILESYSTEM
+#ifndef __NuttX__
   typedef int DIR;
+#endif
 #endif  // _RCUTILS_NO_FILESYSTEM
 typedef struct rcutils_dir_iter_state_t
 {

--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -59,9 +59,7 @@ extern "C"
 #endif  // _WIN32
 
 #ifdef RCUTILS_NO_FILESYSTEM
-#ifndef __NuttX__
   typedef int DIR;
-#endif
 #endif  // _RCUTILS_NO_FILESYSTEM
 typedef struct rcutils_dir_iter_state_t
 {

--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -59,7 +59,9 @@ extern "C"
 #endif  // _WIN32
 
 #ifdef RCUTILS_NO_FILESYSTEM
-typedef int DIR;
+#ifndef __INCLUDE_DIRENT_H
+  typedef int DIR;
+#endif
 #endif  // _RCUTILS_NO_FILESYSTEM
 typedef struct rcutils_dir_iter_state_t
 {
@@ -70,7 +72,7 @@ typedef struct rcutils_dir_iter_state_t
   DIR * dir;
 #endif
 } rcutils_dir_iter_state_t;
-
+ 
 bool
 rcutils_get_cwd(char * buffer, size_t max_length)
 {


### PR DESCRIPTION
The file src/filesystem.c is not compatible with NuttX 11, because of the redefinition of the type "DIR"

src/filesystem.c contains a check of __INCLUDE_DIRENT_H now

The redefinition of the type "DIR" causes a failure of the compilation of the libmicroros.a.