### PR TITLE
Compatibility with NuttX 11

### DIFF
--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -59,7 +59,9 @@ extern "C"
 #endif  // _WIN32
 
 #ifdef RCUTILS_NO_FILESYSTEM
+#ifndef __NuttX__
 typedef int DIR;
+#endif
 #endif  // _RCUTILS_NO_FILESYSTEM
 typedef struct rcutils_dir_iter_state_t
 {


### PR DESCRIPTION
The definition of "DIR" in the src/filesystem.c file causes a failure of the compilation of the libmicroros.a in NuttX.