### PR TITLE
    Fixes to:

### DIFF
--- a/src/error_handling_helpers.h
+++ b/src/error_handling_helpers.h
@@ -86,6 +86,8 @@ __rcutils_copy_string(char * dst, size_t dst_size, const char * src)
 }
 
 // do not use externally, internal function which is only to be used by error_handling.c
+
+#if !defined(RCUTILS_AVOID_DYNAMIC_ALLOCATION)
 static
 void
 __rcutils_reverse_str(char * string_in, size_t string_len)
@@ -102,13 +104,15 @@ __rcutils_reverse_str(char * string_in, size_t string_len)
     string_in[j] = c;
   }
 }
+#endif
+
+#if !defined(RCUTILS_AVOID_DYNAMIC_ALLOCATION)
 
 // do not use externally, internal function which is only to be used by error_handling.c
 static
 void
 __rcutils_convert_uint64_t_into_c_str(uint64_t number, char * buffer, size_t buffer_size)
 {
-#if !defined(RCUTILS_AVOID_DYNAMIC_ALLOCATION)
   assert(buffer != NULL);
   assert(buffer_size >= 21);
   (void)buffer_size;  // prevent warning in release builds where there is no assert(...)
@@ -132,9 +136,8 @@ __rcutils_convert_uint64_t_into_c_str(uint64_t number, char * buffer, size_t buf
 
   // reverse the string in place
   __rcutils_reverse_str(buffer, strnlen(buffer, 21));
-#endif
 }
-
+#endif
 // do not use externally, internal function which is only to be used by error_handling.c
 static
 void
@@ -176,6 +179,9 @@ __rcutils_format_error_string(
   written = __rcutils_copy_string(offset, bytes_left, line_number_buffer);
   offset += written;
   offset[0] = '\0';
+#else
+  (void)error_string;
+  (void)error_state;
 #endif
 }
 

--- a/src/logging.c
+++ b/src/logging.c
@@ -150,6 +150,8 @@ static enum rcutils_get_env_retval rcutils_get_env_var_zero_or_one(
   const char * one_semantic)
 {
   const char * env_var_value = NULL;
+  (void)one_semantic;
+  (void)zero_semantic;
   const char * ret_str = rcutils_get_env(name, &env_var_value);
   if (NULL != ret_str) {
     RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
@@ -1151,6 +1153,12 @@ rcutils_ret_t rcutils_logging_format_message(
 # define COLOR_GREEN 2
 # define COLOR_YELLOW 6
 # define IS_STREAM_A_TTY(stream) (_isatty(_fileno(stream)) != 0)
+#elif defined(__ZEPHYR__)
+# define COLOR_NORMAL 0
+# define COLOR_RED 0
+# define COLOR_GREEN 0
+# define COLOR_YELLOW 0
+# define IS_STREAM_A_TTY(stream) false
 #else
 # define COLOR_NORMAL "\033[0m"
 # define COLOR_RED "\033[31m"
@@ -1252,6 +1260,8 @@ rcutils_ret_t rcutils_logging_format_message(
   }
 # define SET_STANDARD_COLOR_IN_STREAM(is_colorized, status)
 #endif
+static  char msg_buf[1024] = ""; 
+static  char output_buf[1024] = ""; 
 
 void rcutils_logging_console_output_handler(
   const rcutils_log_location_t * location,
@@ -1288,7 +1298,6 @@ void rcutils_logging_console_output_handler(
     is_colorized = IS_STREAM_A_TTY(g_output_stream);
   }
 
-  char msg_buf[1024] = "";
   rcutils_char_array_t msg_array = {
     .buffer = msg_buf,
     .owns_buffer = false,
@@ -1297,7 +1306,6 @@ void rcutils_logging_console_output_handler(
     .allocator = g_rcutils_logging_allocator
   };
 
-  char output_buf[1024] = "";
   rcutils_char_array_t output_array = {
     .buffer = output_buf,
     .owns_buffer = false,

--- a/src/strcasecmp.c
+++ b/src/strcasecmp.c
@@ -19,6 +19,7 @@ extern "C"
 
 #include <errno.h>
 #include <string.h>
+#include <strings.h>
 
 #include "rcutils/strcasecmp.h"
 


### PR DESCRIPTION
     - avoid compiler warnings
     - avoid unnecessary stack allocations in every log message call.
     - avoid unnecessary reference to isatty() when building in Zephyr.

    Signed-off-by: David M. Rensberger <davidr@beechwoods.com>