### PR TITLE
Don't export dl library when not used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -599,7 +599,10 @@ endif()
 
 # Export old-style CMake variables
 ament_export_include_directories("include/${PROJECT_NAME}")
-ament_export_libraries(${PROJECT_NAME} ${CMAKE_DL_LIBS})
+
+if(NOT RCUTILS_NO_FILESYSTEM)
+  ament_export_libraries(${PROJECT_NAME} ${CMAKE_DL_LIBS})
+endif()
 
 # Export modern CMake targets
 ament_export_targets(${PROJECT_NAME})


### PR DESCRIPTION
Avoids a spam of CMake warnings:
```
Package 'rcutils' exports library 'dl' which couldn't be found
```