### PR TITLE
Fix test target link libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,7 +291,7 @@ if(BUILD_TESTING)
   )
   if(TARGET test_error_handling_helpers)
     target_include_directories(test_error_handling_helpers PUBLIC include)
-    target_link_libraries(test_error_handling_helpers osrf_testing_tools_cpp::memory_tools)
+    target_link_libraries(test_error_handling_helpers ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools)
   endif()
 
   ament_add_gtest(test_split


### PR DESCRIPTION
Add `rcutils` to `target_link_libraries` for target `test_error_handling_helpers`.
This caused failure when building the tests. Building only rcutils with colcon also failed.
Will backport to jazzy, humble and rolling.