### PR TITLE
update the headers for zephyr versions 4.2+

### DIFF
--- a/src/time_unix.c
+++ b/src/time_unix.c
@@ -33,8 +33,11 @@ extern "C"
 
 #if defined(__ZEPHYR__)
 #include <version.h>
-#if ZEPHYR_VERSION_CODE >= ZEPHYR_VERSION(3, 1, 0)
+#if (ZEPHYR_VERSION_CODE >= ZEPHYR_VERSION(3, 1, 0)) &&                        \
+    (ZEPHYR_VERSION_CODE < ZEPHYR_VERSION(4, 2, 0))
 #include <zephyr/posix/time.h>  //  Points to Zephyr toolchain posix time implementation
+#elif ZEPHYR_VERSION_CODE >= ZEPHYR_VERSION(4, 2, 0)
+#include <zephyr/posix/sys/time.h> //  Points to Zephyr toolchain posix time implementation
 #else
 #include <time.h>
 #endif // ZEPHYR_VERSION_CODE >= ZEPHYR_VERSION(3, 1, 0)


### PR DESCRIPTION
For Zephyr 4.2 and above there were some changes of the posix time header paths. I have just added conditions such that it will work for zepher versions prior to zephyr 4.2 and also 4.2 and onwards. 

signed-off-by: Furhad Jidda