### PR TITLE
Add RCUTILS_NO_PROCESS_SUPPORT option to build without fork/exec/wait

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(rcutils)
 
 option(RCUTILS_NO_THREAD_SUPPORT "Disable thread support." OFF)
 option(RCUTILS_NO_FILESYSTEM "Disable filesystem usage." OFF)
+option(RCUTILS_NO_PROCESS_SUPPORT "Disable process support." OFF)
 option(RCUTILS_AVOID_DYNAMIC_ALLOCATION "Disable dynamic allocations." OFF)
 option(RCUTILS_NO_64_ATOMIC "Enable alternative support for 64 bits atomic operations in platforms with no native support." OFF)
 option(RCUTILS_MICROROS "Flag for building micro-ROS." ON)
@@ -517,14 +518,16 @@ if(BUILD_TESTING)
     target_link_libraries(test_cmdline_parser ${PROJECT_NAME})
   endif()
 
-  ament_add_gtest(test_process
-    test/test_process.cpp
-  )
-  if(TARGET test_process)
-    target_link_libraries(test_process ${PROJECT_NAME})
-    target_compile_definitions(test_process PRIVATE
-      "CMAKE_COMMAND=${CMAKE_COMMAND}")
-    file(TOUCH "${CMAKE_CURRENT_BINARY_DIR}/file with space.txt")
+  if(NOT RCUTILS_NO_PROCESS_SUPPORT)
+    ament_add_gtest(test_process
+      test/test_process.cpp
+    )
+    if(TARGET test_process)
+      target_link_libraries(test_process ${PROJECT_NAME})
+      target_compile_definitions(test_process PRIVATE
+        "CMAKE_COMMAND=${CMAKE_COMMAND}")
+      file(TOUCH "${CMAKE_CURRENT_BINARY_DIR}/file with space.txt")
+    endif()
   endif()
 
   ament_add_gtest(test_logging_custom_env test/test_logging_custom_env.cpp

--- a/include/rcutils/configuration_flags.h.in
+++ b/include/rcutils/configuration_flags.h.in
@@ -8,6 +8,7 @@ extern "C"
 #endif
 
 #cmakedefine RCUTILS_NO_FILESYSTEM
+#cmakedefine RCUTILS_NO_PROCESS_SUPPORT
 #cmakedefine RCUTILS_AVOID_DYNAMIC_ALLOCATION
 #cmakedefine RCUTILS_NO_THREAD_SUPPORT
 #cmakedefine RCUTILS_MICROROS

--- a/src/process.c
+++ b/src/process.c
@@ -17,6 +17,8 @@ extern "C"
 {
 #endif
 
+#include "rcutils/process.h"
+
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
@@ -36,14 +38,15 @@ extern "C"
 #pragma warning(pop)
 #else
 #include <libgen.h>
+#ifndef RCUTILS_NO_PROCESS_SUPPORT
 #include <sys/wait.h>
+#endif
 #include <unistd.h>
 #endif
 
 #include "rcutils/allocator.h"
 #include "rcutils/error_handling.h"
 #include "rcutils/join.h"
-#include "rcutils/process.h"
 #include "rcutils/strdup.h"
 
 int rcutils_get_pid(void)
@@ -233,6 +236,12 @@ rcutils_start_process(
   const rcutils_string_array_t * args,
   rcutils_allocator_t * allocator)
 {
+#ifdef RCUTILS_NO_PROCESS_SUPPORT
+  (void)args;
+  (void)allocator;
+  RCUTILS_SET_ERROR_MSG("process support is disabled (RCUTILS_NO_PROCESS_SUPPORT)");
+  return NULL;
+#else
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(args, NULL);
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(allocator, NULL);
   if (args->size < 1) {
@@ -318,6 +327,7 @@ rcutils_start_process(
   allocator->deallocate(argv, &allocator->state);
   exit(127);
 #endif
+#endif  // RCUTILS_NO_PROCESS_SUPPORT
 }
 
 void
@@ -341,6 +351,12 @@ rcutils_process_close(rcutils_process_t * process)
 rcutils_ret_t
 rcutils_process_wait(const rcutils_process_t * process, int * exit_code)
 {
+#ifdef RCUTILS_NO_PROCESS_SUPPORT
+  (void)process;
+  (void)exit_code;
+  RCUTILS_SET_ERROR_MSG("process support is disabled (RCUTILS_NO_PROCESS_SUPPORT)");
+  return RCUTILS_RET_ERROR;
+#else
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(process, RCUTILS_RET_INVALID_ARGUMENT);
 
 #if defined _WIN32 || defined __CYGWIN__
@@ -381,6 +397,7 @@ rcutils_process_wait(const rcutils_process_t * process, int * exit_code)
 #endif
 
   return RCUTILS_RET_OK;
+#endif  // RCUTILS_NO_PROCESS_SUPPORT
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Addresses https://github.com/micro-ROS/micro_ros_setup/issues/813

This is my first PR to `rcutils`, I am not particularly familiar with the repo and I did use AI to generate some of the code. But I tried to make sure that the new option is like the other options, and I have built and made sure that with the flag set that it runs on my machine (YRC1000 with a custom micro-ros build). 

With `RCUTILS_NO_PROCESS_SUPPORT` not set, it does not compile for my target machine, as expected. Though it works on my dev PC either way. I am of course not using `rcutils_start_process` or `rcutils_process_wait` in any MotoROS2 code, I just did this so I could get rid of the symbols and compile. 

I know that the colcon metas will need to be updated with this new option, but I am not familiar enough with the different micro-ros platforms to know which ones do and which ones should be set to ON and which ones should be set to OFF. 

I had to move a header. Originally I just included `configuration_flags.h` directly but the linter didn't like that. 