### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/fork_checker.yml
+++ b/.github/workflows/fork_checker.yml
@@ -14,7 +14,7 @@ jobs:
         strategy:
           fail-fast: false
           matrix:
-            branches: [humble, jazzy, kilted, master]
+            branches: [humble, jazzy, kilted, lyrical, rolling]
         steps:
           - name: Check
             id: check

--- a/.github/workflows/humble-ci.yml
+++ b/.github/workflows/humble-ci.yml
@@ -1,0 +1,16 @@
+name: rcutils CI Humble
+
+on:
+  push:
+    branches: [ humble ]
+  pull_request:
+    branches: [ humble ]
+
+jobs:
+  humble-ci:
+    uses: ./.github/workflows/reusable-ci.yml
+    with:
+      branch: ${{ github.ref }}
+      os: ubuntu-22.04
+      docker-image: ubuntu:jammy
+      ros-distribution: humble

--- a/.github/workflows/jazzy-ci.yml
+++ b/.github/workflows/jazzy-ci.yml
@@ -1,0 +1,16 @@
+name: rcutils CI Jazzy
+
+on:
+  push:
+    branches: [ jazzy ]
+  pull_request:
+    branches: [ jazzy ]
+
+jobs:
+  jazzy-ci:
+    uses: ./.github/workflows/reusable-ci.yml
+    with:
+      branch: ${{ github.ref }}
+      os: ubuntu-24.04
+      docker-image: ubuntu:noble
+      ros-distribution: jazzy

--- a/.github/workflows/kilted-ci.yml
+++ b/.github/workflows/kilted-ci.yml
@@ -1,0 +1,16 @@
+name: rcutils CI Kilted
+
+on:
+  push:
+    branches: [ kilted ]
+  pull_request:
+    branches: [ kilted ]
+
+jobs:
+  kilted-ci:
+    uses: ./.github/workflows/reusable-ci.yml
+    with:
+      branch: ${{ github.ref }}
+      os: ubuntu-24.04
+      docker-image: ubuntu:noble
+      ros-distribution: kilted

--- a/.github/workflows/lyrical-ci.yml
+++ b/.github/workflows/lyrical-ci.yml
@@ -1,0 +1,16 @@
+name: rcutils CI Lyrical
+
+on:
+  push:
+    branches: [ lyrical ]
+  pull_request:
+    branches: [ lyrical ]
+
+jobs:
+  lyrical-ci:
+    uses: ./.github/workflows/reusable-ci.yml
+    with:
+      branch: ${{ github.ref }}
+      os: ubuntu-26.04
+      docker-image: ubuntu:resolute
+      ros-distribution: lyrical

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -1,0 +1,56 @@
+name: Reusable rcutils CI
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: "The rcutils branch to use for the workflow"
+        required: true
+        type: string
+      os:
+        description: "The OS to use for the workflow"
+        required: true
+        type: string
+      docker-image:
+        description: "The docker image to use for the workflow"
+        required: true
+        type: string
+      ros-distribution:
+        description: "The ROS distribution to use for the workflow"
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ${{ inputs.os }}
+    strategy:
+      fail-fast: false
+    container:
+      image: ${{ inputs.docker-image }}
+    steps:
+
+    - run: |
+        apt-get update && apt-get install -y git
+      shell: bash
+
+    - name: Sync repository
+      uses: actions/checkout@v5
+      with:
+        ref: ${{ inputs.branch }}
+        submodules: recursive
+
+    - name: Setup ROS 2 
+      uses: ros-tooling/setup-ros@0.7.19
+      with:
+        required-ros-distributions: ${{ inputs.ros-distribution }}
+
+    - name : Download and install rcutils-dependencies
+      run: |
+        apt-get install ros-${{ inputs.ros-distribution }}-mimick-vendor
+        apt-get -y install ros-${{ inputs.ros-distribution }}-performance-test-fixture
+
+    - uses : ros-tooling/action-ros-ci@0.4.8
+      with:
+        package-name: "rcutils"
+        target-ros2-distro: ${{ inputs.ros-distribution }}
+        skip-tests: true

--- a/.github/workflows/rolling-ci.yml
+++ b/.github/workflows/rolling-ci.yml
@@ -1,0 +1,16 @@
+name: rcutils CI Rolling
+
+on:
+  push:
+    branches: [ rolling ]
+  pull_request:
+    branches: [ rolling ]
+
+jobs:
+  rolling-ci:
+    uses: ./.github/workflows/reusable-ci.yml
+    with:
+      branch: ${{ github.ref }}
+      os: ubuntu-24.04
+      docker-image: ubuntu:noble
+      ros-distribution: rolling

--- a/.github/workflows/weekly-ci.yml
+++ b/.github/workflows/weekly-ci.yml
@@ -1,0 +1,44 @@
+name: rcutils weekly CI (all distributions)
+
+on:
+  schedule:
+    # Run once per week to detect broken dependencies.
+    - cron: '59 23 * * 0'
+  workflow_dispatch:
+
+jobs:
+  humble-ci:
+    uses: ./.github/workflows/reusable-ci.yml
+    with:
+      branch: humble
+      os: ubuntu-22.04
+      docker-image: ubuntu:jammy
+      ros-distribution: humble
+  jazzy-ci:
+    uses: ./.github/workflows/reusable-ci.yml
+    with:
+      branch: jazzy
+      os: ubuntu-24.04
+      docker-image: ubuntu:noble
+      ros-distribution: jazzy
+  kilted-ci:
+    uses: ./.github/workflows/reusable-ci.yml
+    with:
+      branch: kilted
+      os: ubuntu-24.04
+      docker-image: ubuntu:noble
+      ros-distribution: kilted
+  lyrical-ci:
+    uses: ./.github/workflows/reusable-ci.yml
+    with:
+      branch: lyrical
+      os: ubuntu-26.04
+      docker-image: ubuntu:resolute
+      ros-distribution: lyrical
+  rolling-ci:
+    uses: ./.github/workflows/reusable-ci.yml
+    with:
+      branch: rolling
+      os: ubuntu-24.04
+      docker-image: ubuntu:noble
+      ros-distribution: rolling


### PR DESCRIPTION
This is an updated version of #43 to account for `lyrical`.

**Main changes:**
- Added `lyrical` workflow
- Included `lyrical`in the fork checker
- Added a `lyrical` job in the weekly CI
- Bump `ros-tooling/setup-ros` from `0.7.15` to `0.7.19` in `reusable-ci.yml`
- Bump `ros-tooling/action-ros-ci` from `0.4.5` to `0.4.8` in `reusable-ci.yml` to have `lyrical` as a valid `ros2` distro 